### PR TITLE
Hotcaching middleware

### DIFF
--- a/middleware/hotcache/hotcache.go
+++ b/middleware/hotcache/hotcache.go
@@ -1,0 +1,57 @@
+// Package hotcache intercepts and group equal requests,
+// perform a single server request.
+// Is ideal for caching really hot pages, like front pages.
+// Is not ideal for caching responses that depends on the logged user.
+package hotcache
+
+import (
+	"github.com/estebarb/ion/futures"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"time"
+)
+
+// Config contains the configuration for hot caching of requests
+type Config struct {
+	l       sync.Mutex
+	timeout time.Duration
+	content map[string]*futures.Expirable
+}
+
+// New creates a new configurated Config for hot caching
+func New(timeout time.Duration) *Config {
+	return &Config{
+		timeout: timeout,
+		content: make(map[string]*futures.Expirable),
+	}
+}
+
+func execute(r *http.Request, next http.Handler) *httptest.ResponseRecorder {
+	wrec := httptest.NewRecorder()
+	next.ServeHTTP(wrec, r)
+	return wrec
+}
+
+// Middleware wraps a request and hot caches it
+func (c *Config) Middleware(next http.Handler) http.Handler {
+	fun := func(w http.ResponseWriter, r *http.Request) {
+		c.l.Lock()
+		expirable, ok := c.content[r.URL.Path]
+		if !ok {
+			expirable = futures.NewExpirable(c.timeout,
+				func() interface{} {
+					return execute(r, next)
+				})
+			c.content[r.URL.Path] = expirable
+		}
+		c.l.Unlock()
+		recorded := expirable.Read().(*httptest.ResponseRecorder)
+		for k, v := range recorded.Header() {
+			w.Header()[k] = v
+		}
+		w.WriteHeader(recorded.Code)
+		w.Write(recorded.Body.Bytes())
+	}
+	return http.HandlerFunc(fun)
+}

--- a/middleware/hotcache/hotcache_test.go
+++ b/middleware/hotcache/hotcache_test.go
@@ -1,0 +1,59 @@
+package hotcache
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+)
+
+const ExpectedDuration = time.Millisecond * 50
+
+func SlowResponse(w http.ResponseWriter, r *http.Request) {
+	time.Sleep(ExpectedDuration)
+	w.Header().Add("hello", "world")
+	w.Write([]byte("hello"))
+}
+
+func TestConfig_Middleware(t *testing.T) {
+	hc := New(time.Second * 3)
+	h := hc.Middleware(http.HandlerFunc(SlowResponse))
+	start := time.Now()
+
+	ts := httptest.NewServer(h)
+
+	var wg sync.WaitGroup
+
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			req, err := http.Get(ts.URL + "/")
+			if err != nil {
+				t.Error(err)
+			}
+			if req.Header.Get("hello") != "world" {
+				t.Errorf("Expecting header hello:world, got %v", req.Header)
+			}
+			buf, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				t.Error(err)
+			}
+			if string(buf) != "hello" {
+				t.Errorf("Expecting 'hello', got %v", string(buf))
+			}
+			req.Body.Close()
+		}()
+	}
+	wg.Wait()
+	duration := time.Since(start)
+	if duration < ExpectedDuration {
+		t.Errorf("Expected duration was at least %v, takes %v", ExpectedDuration, duration)
+	}
+
+	if duration > ExpectedDuration+time.Millisecond*25 {
+		t.Errorf("Expected duration was more or less %v, takes %v", ExpectedDuration, duration)
+	}
+}


### PR DESCRIPTION
In some situations a page is very popular, but it doesn't
have changes related with user session. In this case
the package hotcache allows to save a response and just
repeat this response for others request, until the timeout
is meet.

Signed-off-by: Esteban Rodríguez Betancourt <estebarb@gmail.com>